### PR TITLE
fix: add /bojuvue/ redirect to /BojuVue/

### DIFF
--- a/bojuvue/index.html
+++ b/bojuvue/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/BojuVue/">
+  <link rel="canonical" href="/BojuVue/">
+  <title>Redirecting to BojuVue...</title>
+</head>
+<body>
+  <script>window.location.replace('/BojuVue/');</script>
+  <p>Redirecting to <a href="/BojuVue/">BojuVue docs</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `bojuvue/index.html` with a meta-refresh + JS redirect from `/bojuvue/` → `/BojuVue/`
- Creates a lowercase alias matching the npm package name (`bojuvue`)
- Works on Jekyll's static output without any plugin or config change

## Test plan

- [ ] Merge and wait for Pages to rebuild
- [ ] Visit `https://scottkirvan.com/bojuvue/` — should redirect to `https://scottkirvan.com/BojuVue/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)